### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A Model Context Protocol (MCP) server for interacting with Ghost CMS through LLM
 
 ![demo](./assets/ghost-mcp-demo.gif)
 
+<a href="https://glama.ai/mcp/servers/vor63xn7ky"><img width="380" height="200" src="https://glama.ai/mcp/servers/vor63xn7ky/badge" alt="Ghost Server MCP server" /></a>
+
 ## Features
 
 - Secure JWT Authentication for Ghost Admin API requests


### PR DESCRIPTION
This PR adds a badge for the [Ghost MCP Server](https://glama.ai/mcp/servers/vor63xn7ky) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/vor63xn7ky"><img width="380" height="200" src="https://glama.ai/mcp/servers/vor63xn7ky/badge" alt="Ghost Server MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.