### PR TITLE
feat(posts): accept Ghost metadata fields in posts_add + posts_edit

### DIFF
--- a/src/tools/posts.ts
+++ b/src/tools/posts.ts
@@ -14,19 +14,61 @@ const readParams = {
   id: z.string().optional(),
   slug: z.string().optional(),
 };
-const addParams = {
-  title: z.string(),
+// Shared mutable post fields — accepted by both posts_add and posts_edit.
+// Mirrors the Ghost Admin API post resource:
+// https://ghost.org/docs/admin-api/#the-post-object
+const tagRef = z.union([
+  z.string(),
+  z.object({
+    id: z.string().optional(),
+    slug: z.string().optional(),
+    name: z.string().optional(),
+  }),
+]);
+const authorRef = z.union([
+  z.string(),
+  z.object({
+    id: z.string().optional(),
+    slug: z.string().optional(),
+    email: z.string().optional(),
+  }),
+]);
+const postMutableFields = {
   html: z.string().optional(),
   lexical: z.string().optional(),
   status: z.string().optional(),
+  slug: z.string().optional(),
+  visibility: z.string().optional(),
+  featured: z.boolean().optional(),
+  email_only: z.boolean().optional(),
+  published_at: z.string().optional(),
+  custom_excerpt: z.string().optional(),
+  feature_image: z.string().optional(),
+  feature_image_alt: z.string().optional(),
+  feature_image_caption: z.string().optional(),
+  meta_title: z.string().optional(),
+  meta_description: z.string().optional(),
+  og_title: z.string().optional(),
+  og_description: z.string().optional(),
+  og_image: z.string().optional(),
+  twitter_title: z.string().optional(),
+  twitter_description: z.string().optional(),
+  twitter_image: z.string().optional(),
+  codeinjection_head: z.string().optional(),
+  codeinjection_foot: z.string().optional(),
+  canonical_url: z.string().optional(),
+  tags: z.array(tagRef).optional(),
+  authors: z.array(authorRef).optional(),
+};
+const addParams = {
+  title: z.string(),
+  ...postMutableFields,
 };
 const editParams = {
   id: z.string(),
-  title: z.string().optional(),
-  html: z.string().optional(),
-  lexical: z.string().optional(),
-  status: z.string().optional(),
   updated_at: z.string(),
+  title: z.string().optional(),
+  ...postMutableFields,
 };
 const deleteParams = {
   id: z.string(),


### PR DESCRIPTION
## Summary

Surface the full mutable post field set on `posts_add` and `posts_edit` so MCP clients can manage SEO metadata, social preview fields, tags, authors, and code injection without bypassing the wrapper.

## Problem

Before this change, `posts_edit` accepted only `{id, title, html, lexical, status, updated_at}`. Fields like `meta_title`, `og_*`, `twitter_*`, `tags`, `codeinjection_head`, `feature_image_alt`, and `custom_excerpt` could not be set via the MCP.

Real-world impact: a workflow that drafted a blog post through Claude + this MCP still required a manual round-trip through Ghost admin to fill in SEO metadata, tags, and Open Graph cards before the post was shippable. Clients had to either call the Ghost Admin API directly (JWT-signed REST, Cloudflare UA handling, etc.) or paste metadata manually.

## Change

Both `posts_add` and `posts_edit` now accept the documented mutable fields from [the Ghost Admin API post resource](https://ghost.org/docs/admin-api/#the-post-object). Fields are extracted into a shared `postMutableFields` object so the two schemas stay in sync.

### New fields (all optional, backwards compatible)

- `slug`, `visibility`, `featured`, `email_only`, `published_at`
- `custom_excerpt`
- `feature_image`, `feature_image_alt`, `feature_image_caption`
- `meta_title`, `meta_description`
- `og_title`, `og_description`, `og_image`
- `twitter_title`, `twitter_description`, `twitter_image`
- `codeinjection_head`, `codeinjection_foot`
- `canonical_url`
- `tags` — accepts `string` (slug) or `{ id?, slug?, name? }`
- `authors` — accepts `string` (slug) or `{ id?, slug?, email? }`

### What I did NOT touch

- Existing fields (`title`, `html`, `lexical`, `status`, `id`, `updated_at`) are unchanged
- `posts_browse` / `posts_read` / `posts_delete` untouched
- No version bump — leaving that to the maintainer's release flow
- `package-lock.json` — restored after `npm install` drift so the diff stays focused on the schema change

## Why `@tryghost/admin-api` already handles it

The underlying SDK forwards arbitrary fields on `posts.edit(args, options)` and `posts.add(args, options)` to Ghost's REST API, which validates server-side. The only thing blocking clients was the Zod schema on the MCP tool — this PR just widens the gate.

## Test plan

- [x] `npm run build` — TypeScript compiles with no errors
- [x] `grep` compiled output for new field names — all present in `build/tools/posts.js`
- [x] Verified end-to-end on my own Ghost instance by calling the Ghost Admin API directly with the exact same field set — all fields persist correctly (this PR just enables sending them through MCP)
- [ ] Maintainer: smoke test via a real MCP client (Claude Desktop etc.) if desired

## Notes

- All added fields are `.optional()` — existing callers that send only `title`/`html`/`status` are unaffected
- `tags` and `authors` accept both string-slug shorthand and full object refs, matching how `@tryghost/admin-api` normalizes them

🤖 Generated with [Claude Code](https://claude.com/claude-code)