### PR TITLE
fix: move capabilities to McpServer options argument

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import {
 const server = new McpServer({
     name: "ghost-mcp-ts",
     version: "1.0.0", // TODO: Get version from package.json
+}, {
     capabilities: {
         resources: {}, // Capabilities will be enabled as handlers are registered
         tools: {},


### PR DESCRIPTION
## Summary

- Fixes build failure (`TS2353`) caused by passing `capabilities` in the wrong argument to the `McpServer` constructor
- The `@modelcontextprotocol/sdk` (>=1.12) moved `capabilities` from the first arg (`Implementation`) to the second arg (`ServerOptions`)

Fixes #18

## Test plan

- [ ] `npm run build` completes without errors
- [ ] Server starts successfully via `npm start`

🤖 Generated with [Claude Code](https://claude.ai/code)